### PR TITLE
Full path import of libvirt_schema

### DIFF
--- a/libvirt_exporter.go
+++ b/libvirt_exporter.go
@@ -23,7 +23,7 @@ import (
 
 	libvirt "github.com/libvirt/libvirt-go"
 
-	"./libvirt_schema"
+	"github.com/kumina/libvirt_exporter/libvirt_schema"
 )
 
 var (


### PR DESCRIPTION
I was unable to compile libvirt_exporter (go install) without full path import of libvirt_schema. 