### PR TITLE
Workaround for empty interface name in case of "hostdev" interfaces

### DIFF
--- a/libvirt_exporter.go
+++ b/libvirt_exporter.go
@@ -266,6 +266,9 @@ func CollectDomain(ch chan<- prometheus.Metric, domain *libvirt.Domain) error {
 
 	// Report network interface statistics.
 	for _, iface := range desc.Devices.Interfaces {
+		if iface.Target.Device == "" {
+			continue
+		}
 		interfaceStats, err := domain.InterfaceStats(iface.Target.Device)
 		if err != nil {
 			return err


### PR DESCRIPTION
This pull request fixes https://github.com/kumina/libvirt_exporter/issues/5 by adding a simple if and ignoring devices without "target" interface name.