### PR TITLE
Skip disks that does not have stat

### DIFF
--- a/libvirt_exporter.go
+++ b/libvirt_exporter.go
@@ -183,6 +183,10 @@ func CollectDomain(ch chan<- prometheus.Metric, domain *libvirt.Domain) error {
 
 	// Report block device statistics.
 	for _, disk := range desc.Devices.Disks {
+		if disk.Device == "cdrom" || disk.Device == "fd" {
+			continue
+		}
+
 		blockStats, err := domain.BlockStats(disk.Target.Device)
 		if err != nil {
 			return err

--- a/libvirt_schema/schema.go
+++ b/libvirt_schema/schema.go
@@ -23,6 +23,7 @@ type Devices struct {
 }
 
 type Disk struct {
+	Device string     `xml:"device,attr"`
 	Source DiskSource `xml:"source"`
 	Target DiskTarget `xml:"target"`
 }


### PR DESCRIPTION
We get "internal error: cannot find statistics for device ..." error for CDROM or Floppy.
This is same with apache/cloudstack#2131