### PR TITLE
Add `--libvirt.export-nova-metadata` hint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,30 @@ with older versions of libvirt that don't support this API call.
 The following metrics/labels are being exported:
 
 ```
-libvirt_domain_block_stats_read_bytes_total{domain="...",source_file="...",target_device="..."}
-libvirt_domain_block_stats_read_requests_total{domain="...",source_file="...",target_device="..."}
-libvirt_domain_block_stats_write_bytes_total{domain="...",source_file="...",target_device="..."}
-libvirt_domain_block_stats_write_requests_total{domain="...",source_file="...",target_device="..."}
-libvirt_domain_info_cpu_time_seconds_total{domain="..."}
-libvirt_domain_info_maximum_memory_bytes{domain="..."}
-libvirt_domain_info_memory_usage_bytes{domain="..."}
-libvirt_domain_info_virtual_cpus{domain="..."}
-libvirt_domain_interface_stats_receive_bytes_total{domain="...",source_bridge="...",target_device="..."}
-libvirt_domain_interface_stats_receive_drops_total{domain="...",source_bridge="...",target_device="..."}
-libvirt_domain_interface_stats_receive_errors_total{domain="...",source_bridge="...",target_device="..."}
-libvirt_domain_interface_stats_receive_packets_total{domain="...",source_bridge="...",target_device="..."}
-libvirt_domain_interface_stats_transmit_bytes_total{domain="...",source_bridge="...",target_device="..."}
-libvirt_domain_interface_stats_transmit_drops_total{domain="...",source_bridge="...",target_device="..."}
-libvirt_domain_interface_stats_transmit_errors_total{domain="...",source_bridge="...",target_device="..."}
-libvirt_domain_interface_stats_transmit_packets_total{domain="...",source_bridge="...",target_device="..."}
+libvirt_domain_block_stats_read_bytes_total{domain="...",uuid="...",source_file="...",target_device="..."}
+libvirt_domain_block_stats_read_requests_total{domain="...",uuid="...",source_file="...",target_device="..."}
+libvirt_domain_block_stats_write_bytes_total{domain="...",uuid="...",source_file="...",target_device="..."}
+libvirt_domain_block_stats_write_requests_total{domain="...",uuid="...",source_file="...",target_device="..."}
+libvirt_domain_info_cpu_time_seconds_total{domain="...",uuid="..."}
+libvirt_domain_info_maximum_memory_bytes{domain="...",uuid="..."}
+libvirt_domain_info_memory_usage_bytes{domain="...",uuid="..."}
+libvirt_domain_info_virtual_cpus{domain="...",uuid="..."}
+libvirt_domain_interface_stats_receive_bytes_total{domain="...",uuid="...",source_bridge="...",target_device="..."}
+libvirt_domain_interface_stats_receive_drops_total{domain="...",uuid="...",source_bridge="...",target_device="..."}
+libvirt_domain_interface_stats_receive_errors_total{domain="...",uuid="...",source_bridge="...",target_device="..."}
+libvirt_domain_interface_stats_receive_packets_total{domain="...",uuid="...",source_bridge="...",target_device="..."}
+libvirt_domain_interface_stats_transmit_bytes_total{domain="...",uuid="...",source_bridge="...",target_device="..."}
+libvirt_domain_interface_stats_transmit_drops_total{domain="...",uuid="...",source_bridge="...",target_device="..."}
+libvirt_domain_interface_stats_transmit_errors_total{domain="...",uuid="...",source_bridge="...",target_device="..."}
+libvirt_domain_interface_stats_transmit_packets_total{domain="...",uuid="...",source_bridge="...",target_device="..."}
 libvirt_up
 ```
+
+With the `--libvirt.export-nova-metadata` flag, it will export the following additional OpenStack-specific labels for every domain:
+
+- name
+- flavor
+- project_name
 
 At Kumina we want to perform a single build of this exporter, deploying
 it to a variety of Linux distribution versions. This is why this


### PR DESCRIPTION
#19 added a CLI option and additional labels, and I forgot to add that to the README