### PR TITLE
Replace prometheus.Handler by promhttp.Handler

### DIFF
--- a/libvirt_exporter.go
+++ b/libvirt_exporter.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/libvirt/libvirt-go"
 	"github.com/prometheus/client_golang/prometheus"
+        "github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kumina/libvirt_exporter/libvirt_schema"
@@ -460,7 +461,7 @@ func main() {
 	}
 	prometheus.MustRegister(exporter)
 
-	http.Handle(*metricsPath, prometheus.Handler())
+	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`
 			<html>


### PR DESCRIPTION
prometheus.Handler() is now deprecated and it needs to be replaced
by promhttp.Handler()