### PR TITLE
Version update

### DIFF
--- a/build_binary.sh
+++ b/build_binary.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+docker run -i -v `pwd`:/gopath/src/github.com/kumina/libvirt_exporter alpine:3.10.5 /bin/sh << 'EOF'
+set -ex
+
+# Install prerequisites for the build process.
+apk update
+apk add ca-certificates gcc g++ git go libnl-dev make perl pkgconf \
+libnl3-dev libxml2-dev libxslt-dev libtasn1-dev libvirt-dev
+update-ca-certificates
+
+cd /gopath/src/github.com/kumina/libvirt_exporter
+go get -d ./...
+go build 
+strip libvirt_exporter
+EOF

--- a/build_static.sh
+++ b/build_static.sh
@@ -5,32 +5,41 @@ set -ex
 
 # Install prerequisites for the build process.
 apk update
-apk add ca-certificates g++ git go libnl-dev linux-headers make perl pkgconf libtirpc-dev wget
+apk add ca-certificates gcc g++ git go libnl-dev linux-headers make perl pkgconf \
+libtirpc-dev wget gnutls-dev libxslt-dev python3-dev xen-dev libxml2-utils libpciaccess-dev \
+libxml2-dev netcf-dev libnl3-dev libxml2-dev libxslt-dev libtasn1-dev
+apk --update add go
 update-ca-certificates
 
 # Install libxml2. Alpine's version does not ship with a static library.
-cd /tmp
-wget ftp://xmlsoft.org/libxml2/libxml2-2.9.9.tar.gz
-tar -xf libxml2-2.9.9.tar.gz
-cd libxml2-2.9.9
-./configure --disable-shared --enable-static
-make -j2
-make install
+#cd /tmp
+#wget ftp://xmlsoft.org/libxml2/libxml2-2.9.10.tar.gz
+#tar -xf libxml2-2.9.10.tar.gz
+#cd libxml2-2.9.10
+#./configure --disable-shared --enable-static
+#make -j2
+#make install
 
 # Install libvirt. Alpine's version does not ship with a static library.
 cd /tmp
 wget https://libvirt.org/sources/libvirt-5.0.0.tar.xz
 tar -xf libvirt-5.0.0.tar.xz
 cd libvirt-5.0.0
-./configure --disable-shared --enable-static --localstatedir=/var --without-storage-mpath
-make -j2
+CFLAGS="-fPIC"
+# ./configure --disable-shared --enable-static --localstatedir=/var  \
+./configure \
+--without-storage-mpath \
+--without-storage-scsi \
+--without-storage-iscsi \
+--without-storage-fs 
+make 
 make install
+
 sed -i 's/^Libs:.*/& -lnl -ltirpc -lxml2/' /usr/local/lib/pkgconfig/libvirt.pc
 
 # Build the libvirt_exporter.
 cd /gopath/src/github.com/kumina/libvirt_exporter
-export GOPATH=/gopath
 go get -d ./...
-go build --ldflags '-extldflags "-static"'
+go build
 strip libvirt_exporter
 EOF

--- a/build_static.sh
+++ b/build_static.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker run -i -v `pwd`:/gopath/src/github.com/kumina/libvirt_exporter alpine:3.8 /bin/sh << 'EOF'
+docker run -i -v `pwd`:/gopath/src/github.com/kumina/libvirt_exporter alpine:3.13.1 /bin/sh << 'EOF'
 set -ex
 
 # Install prerequisites for the build process.
@@ -10,18 +10,18 @@ update-ca-certificates
 
 # Install libxml2. Alpine's version does not ship with a static library.
 cd /tmp
-wget ftp://xmlsoft.org/libxml2/libxml2-2.9.4.tar.gz
-tar -xf libxml2-2.9.4.tar.gz
-cd libxml2-2.9.4
+wget ftp://xmlsoft.org/libxml2/libxml2-2.9.9.tar.gz
+tar -xf libxml2-2.9.9.tar.gz
+cd libxml2-2.9.9
 ./configure --disable-shared --enable-static
 make -j2
 make install
 
 # Install libvirt. Alpine's version does not ship with a static library.
 cd /tmp
-wget https://libvirt.org/sources/libvirt-3.2.0.tar.xz
-tar -xf libvirt-3.2.0.tar.xz
-cd libvirt-3.2.0
+wget https://libvirt.org/sources/libvirt-5.0.0.tar.xz
+tar -xf libvirt-5.0.0.tar.xz
+cd libvirt-5.0.0
 ./configure --disable-shared --enable-static --localstatedir=/var --without-storage-mpath
 make -j2
 make install


### PR DESCRIPTION
Hi together,

to create an new binary build for libvirt_exporter for Version 5.x
i've built against version alpine version 3.10.5 which include the named version
with this script:

build_binary.sh

to use it in alpine docker container you will need apk add libvirt-libs
why:

https://wiki.openstack.org/wiki/LibvirtDistroSupportMatrix

why not static:

the build process of break with libvirt version 5.0.0
